### PR TITLE
Fixes auth callback url (https)

### DIFF
--- a/lib/omniauth-untappd/version.rb
+++ b/lib/omniauth-untappd/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Untappd
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/lib/omniauth/strategies/untappd.rb
+++ b/lib/omniauth/strategies/untappd.rb
@@ -56,7 +56,7 @@ module OmniAuth
       def raw_info
         access_token.options[:mode] = :query
         access_token.options[:param_name] = :access_token
-        @raw_info ||= access_token.get('http://api.untappd.com/v4/user/info').parsed['response']['user']
+        @raw_info ||= access_token.get('https://api.untappd.com/v4/user/info').parsed['response']['user']
       end
 
       private

--- a/spec/omniauth/strategies/untappd_spec.rb
+++ b/spec/omniauth/strategies/untappd_spec.rb
@@ -12,7 +12,7 @@ describe OmniAuth::Strategies::Untappd do
                                'first_name' => 'John',
                                'last_name' => 'Doe',
                                'user_name' => 'john_doe',
-                               'untappd_url' => 'http://untappd.com/user/john_doe',
+                               'untappd_url' => 'https://untappd.com/user/john_doe',
                                'settings' => {
                                  'email_address' => 'john@doe'
                                }
@@ -62,7 +62,7 @@ describe OmniAuth::Strategies::Untappd do
     subject { strategy.raw_info }
     let(:access_token) { double('AccessToken', options: {}) }
     let(:response) { double('Response', parsed: parsed_response) }
-    let(:user_info_url) { 'http://api.untappd.com/v4/user/info' }
+    let(:user_info_url) { 'https://api.untappd.com/v4/user/info' }
 
     before { strategy.stub(access_token: access_token) }
     before { expect(access_token).to receive(:get).with(user_info_url).and_return(response) }
@@ -81,7 +81,7 @@ describe OmniAuth::Strategies::Untappd do
       it { expect(info[:name]).to eql 'John Doe' }
       it { expect(info[:nickname]).to eql 'john_doe' }
       it { expect(info[:email]).to eql 'john@doe' }
-      it { expect(info[:urls]['Untappd']).to eql 'http://untappd.com/user/john_doe' }
+      it { expect(info[:urls]['Untappd']).to eql 'https://untappd.com/user/john_doe' }
     end
 
     context '#extra' do


### PR DESCRIPTION
Recently Untappd changed it's API by requiring HTTPS to every call. Otherwise it will return `error 500` just like the message below:

`: {"meta":{"code":500,"error_detail":"You must be using HTTPS to connect Untappd's API.","error_type":"invalid_auth","developer_friendly":"","response_time":{"time":0.06,"measure":"seconds"}},"response":[]}`
